### PR TITLE
perf: skip off-screen image viewers during zoom/pan sync

### DIFF
--- a/webapp/src/viewers/images/images.js
+++ b/webapp/src/viewers/images/images.js
@@ -84,13 +84,16 @@ function maintain_zoom() {
     sync_group.leading = "resize";
     try { // we should try to find how to identify when an image is not loaed...
       sync_group.viewers.forEach(v => {
+        if (sync_group.visibility?.[v.id] === false) return; // skip off-screen viewers
         const size = new OpenSeadragon.Point(v.container.clientWidth ?? 1, v.container.clientHeight ?? 1);
         v.viewport.resize(size, true);
         v.viewport.zoomTo(sync_group.zoom, null, true);
         v.viewport.panTo(sync_group.center, true);
       })
       sync_group.leading = null;
-      sync_group.viewers.forEach(v => v.forceRedraw())
+      sync_group.viewers.forEach(v => {
+        if (sync_group.visibility?.[v.id] !== false) v.forceRedraw();
+      })
     } catch { }
   })
 }
@@ -166,8 +169,12 @@ class ImgViewer extends React.PureComponent {
         center: null,
         // When the user moves a viewer, it leads the others
         // whose pan/zoom events we ignore.
-        // Values: the id of a viewer, null, or "all"
+        // Values: the id of a viewer, null, "resize", or "catchup"
         leading: null,
+        // IntersectionObserver visibility per viewer id (false = off-screen, skip sync)
+        visibility: {},
+        // IntersectionObserver instances per viewer id for cleanup
+        observers: {},
       }
     } else {
       if (synced_viewers[sync_key].viewers.every(v => v.id !== viewer_new.id))
@@ -176,6 +183,33 @@ class ImgViewer extends React.PureComponent {
         synced_viewers[sync_key].viewers.push(viewer_ref)
     }
 
+    // Track viewport visibility for each viewer so we can skip off-screen ones during sync.
+    // When a viewer enters the 200px margin it catches up instantly (no animation → no extra tile requests).
+    const setupVisibilityTracking = (viewer) => {
+      if (!viewer.container) return;
+      const sync_group = synced_viewers[sync_key];
+      sync_group.visibility[viewer.id] = false; // assume off-screen until observer fires
+
+      const observer = new IntersectionObserver(([entry]) => {
+        sync_group.visibility[viewer.id] = entry.isIntersecting;
+        if (entry.isIntersecting) {
+          // Catch up to the group's current zoom/center instantly (true = no animation)
+          const { zoom, center } = sync_group;
+          if (zoom !== null && center !== null) {
+            sync_group.leading = 'catchup';
+            viewer.viewport.zoomTo(zoom, null, true);
+            viewer.viewport.panTo(center, true);
+            sync_group.leading = null;
+          }
+        }
+      }, { rootMargin: '200px' });
+
+      observer.observe(viewer.container);
+      sync_group.observers[viewer.id] = observer;
+    };
+
+    setupVisibilityTracking(viewer_new);
+    setupVisibilityTracking(viewer_ref);
 
     var lead_viewer_sync = (sync_key, viewer) => () => {
       // console.log("[lead_viewer_sync]")
@@ -186,13 +220,14 @@ class ImgViewer extends React.PureComponent {
       // synced_viewers[sync_key].width = viewer.source.width
       synced_viewers[sync_key].zoom = viewer.viewport.getZoom();
       synced_viewers[sync_key].center = viewer.viewport.getCenter();
-      // console.log(`leading with ${viewer.id} to ${synced_viewers[sync_key].zoom} / ${synced_viewers[sync_key].center} (${viewer.source.height}:${viewer.source.height})`)      
+      // console.log(`leading with ${viewer.id} to ${synced_viewers[sync_key].zoom} / ${synced_viewers[sync_key].center} (${viewer.source.height}:${viewer.source.height})`)
       if (synced_viewers[sync_key].center === undefined || synced_viewers[sync_key].center === null)
         return
       synced_viewers[sync_key].leading = viewer.id;
       synced_viewers[sync_key].viewers.filter(v => v.id !== viewer.id).forEach(v => {
+        // Skip viewers that are off-screen — they will catch up via IntersectionObserver
+        if (synced_viewers[sync_key].visibility?.[v.id] === false) return;
         // console.log(`  follow for ${v.id} (${v.source.height}:${v.source.width})`)
-        // console.log(v.source.width)
         v.viewport.zoomTo(synced_viewers[sync_key].zoom);
         v.viewport.panTo(synced_viewers[sync_key].center);
       })
@@ -213,6 +248,12 @@ class ImgViewer extends React.PureComponent {
         synced_viewers[sync_key].viewers = synced_viewers[sync_key].viewers.filter(
           v => v.id !== viewer_new.id && v.id !== viewer_ref.id
         )
+        // Disconnect IntersectionObservers for these viewers
+        ;[viewer_new, viewer_ref].forEach(v => {
+          synced_viewers[sync_key].observers?.[v.id]?.disconnect();
+          delete synced_viewers[sync_key].observers?.[v.id];
+          delete synced_viewers[sync_key].visibility?.[v.id];
+        })
       }
       this.UnregisterZoomSync = null;
     }


### PR DESCRIPTION
Use IntersectionObserver (200px rootMargin) to track viewport visibility per viewer. During zoom/pan sync, off-screen viewers are skipped entirely to prevent tile request spikes. When a viewer enters the viewport margin it catches up instantly (immediately=true, no animation) to the group's current zoom/center, triggering a single tile request burst instead of a continuous stream.

Same skip applied to the window resize handler (maintain_zoom).