### PR TITLE
Replace scikit-optimize with Optuna for auto-tuning

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,7 +32,7 @@ scikit-image = "*" # image processing for auto-regions of interest
 uwsgi = "*"        # server
 uwsgitop = "*"     # top for uwsgi
 qaboard = { path = "..", optional = true } #, develop = true }
-scikit-optimize = "*" # needed for auto-tuning, it's specified in qaboard, normally it should be enough but..
+optuna = ">=4.9"      # needed for auto-tuning, it's specified in qaboard[opt], normally it should be enough but..
 
 # Makes incremental docker builds easier
 [tool.poetry.extras]

--- a/qaboard/optimization.py
+++ b/qaboard/optimization.py
@@ -1,0 +1,187 @@
+"""
+QA-Board's auto-tuning configuration dialect.
+
+Users write the `search_space` and `solver` sections of their optimization YAML in the
+web UI, and those configs are saved alongside batches. The dialect is therefore a
+user-facing contract, and this module is deliberately the only place that knows how to
+read it -- the optimization engine underneath is an implementation detail we can swap
+without touching a single user's config.
+
+We learned that the hard way: the dialect used to *be* `skopt.Space.from_yaml()`, so
+when scikit-optimize was archived (2024-02-28, never made numpy-2 compatible) the format
+went down with the library. Now we own it.
+
+The engine is currently Optuna, driven through its ask/tell API.
+"""
+from typing import Any, Dict, List
+
+
+def _import_optuna():
+  try:
+    import optuna
+  except ImportError as e:
+    raise ImportError(
+      "`qa optimize` needs Optuna, which is not installed.\n"
+      "Install it with:\n"
+      "    pip install 'qaboard[opt]'"
+    ) from e
+  return optuna
+
+
+# `search_space` dimensions. The names are historical -- they match what users already
+# have saved in their configs -- but they are ours now, not a third-party library's.
+DIMENSION_KINDS = ('Integer', 'Real', 'Categorical')
+
+# Keys that used to be forwarded as-is to `skopt.Optimizer`. They have no meaning for
+# the current engine, so rather than silently ignoring them we tell users what to write.
+LEGACY_SOLVER_KEYS = {
+  'base_estimator':       "use `sampler: gp` for Gaussian processes, or `sampler: tpe`",
+  'n_initial_points':     "renamed to `n_startup_trials`",
+  'random_state':         "renamed to `seed`",
+  'acq_func':             "acquisition functions are not configurable anymore; `sampler: gp` uses log-EI",
+  'acq_funcstring':       "acquisition functions are not configurable anymore; `sampler: gp` uses log-EI",
+  'acq_optimizer':        "not configurable anymore",
+  'n_restarts_optimizer': "not configurable anymore",
+  'n_jobs':               "use the `parallel_sampling` setting instead",
+  'xi':                   "not configurable anymore",
+  'kappa':                "not configurable anymore",
+}
+
+SAMPLERS = ('gp', 'tpe', 'random')
+
+
+def parse_search_space(search_space: Any) -> Dict[str, Any]:
+  """
+  Read the `search_space` section of an optimization config, and return the parameters
+  to optimize as a {name: distribution} mapping.
+
+  Error messages are shown to users in the web UI, so they name what went wrong and where.
+  """
+  optuna = _import_optuna()
+  from optuna.distributions import CategoricalDistribution, FloatDistribution, IntDistribution
+
+  if not search_space:
+    raise ValueError("ERROR: the configuration must provide a non-empty `search_space`.")
+  if not isinstance(search_space, list):
+    raise ValueError(
+      "ERROR: `search_space` must be a list of dimensions, each written as "
+      "`- Integer:`, `- Real:` or `- Categorical:`."
+    )
+
+  distributions: Dict[str, Any] = {}
+  for index, dimension in enumerate(search_space):
+    at = f"search_space[{index}]"
+    if not isinstance(dimension, dict) or len(dimension) != 1:
+      raise ValueError(
+        f"ERROR: {at} must be a single-key mapping, one of: {', '.join(DIMENSION_KINDS)}."
+      )
+    kind, options = next(iter(dimension.items()))
+    if kind not in DIMENSION_KINDS:
+      raise ValueError(
+        f"ERROR: {at} has unknown dimension type `{kind}`. Expected one of: {', '.join(DIMENSION_KINDS)}."
+      )
+    if not isinstance(options, dict):
+      raise ValueError(f"ERROR: {at} (`{kind}`) must be a mapping with at least a `name`.")
+
+    name = options.get('name')
+    if not name:
+      raise ValueError(f"ERROR: {at} (`{kind}`) is missing a `name`.")
+    if name in distributions:
+      raise ValueError(f"ERROR: `{name}` is defined more than once in the search space.")
+    at = f"search_space[{index}] (`{name}`)"
+
+    if kind == 'Categorical':
+      categories = options.get('categories')
+      if not categories:
+        raise ValueError(f"ERROR: {at} is missing its `categories`.")
+      if not isinstance(categories, list):
+        raise ValueError(f"ERROR: {at} expects `categories` to be a list.")
+      distributions[name] = CategoricalDistribution(categories)
+      continue
+
+    # Integer and Real are both bounded ranges
+    if 'low' not in options or 'high' not in options:
+      raise ValueError(f"ERROR: {at} needs both `low` and `high` bounds.")
+    low, high = options['low'], options['high']
+    if not isinstance(low, (int, float)) or not isinstance(high, (int, float)):
+      raise ValueError(f"ERROR: {at} expects numbers for `low` and `high`.")
+    if low >= high:
+      raise ValueError(f"ERROR: {at} has `low` ({low}) >= `high` ({high}).")
+
+    prior = options.get('prior', 'uniform')
+    if prior not in ('uniform', 'log-uniform'):
+      raise ValueError(
+        f"ERROR: {at} has unknown `prior: {prior}`. Expected `uniform` or `log-uniform`."
+      )
+    log = prior == 'log-uniform'
+    if log and low <= 0:
+      raise ValueError(f"ERROR: {at} uses `prior: log-uniform`, so `low` ({low}) must be > 0.")
+
+    if kind == 'Integer':
+      distributions[name] = IntDistribution(int(low), int(high), log=log)
+    else:
+      distributions[name] = FloatDistribution(float(low), float(high), log=log)
+
+  return distributions
+
+
+def make_study(solver: Dict[str, Any]):
+  """
+  Read the `solver` section of an optimization config, and return the Optuna study that
+  will drive the search. We always minimize: QA-Board's `objective` section already
+  handles per-metric sign inversion via `smaller_is_better`.
+  """
+  optuna = _import_optuna()
+
+  solver = {**solver}
+  name = solver.pop('name', 'optuna')
+  if name != 'optuna':
+    raise ValueError(
+      f"ERROR: unknown solver `name: {name}`. The only supported solver is `optuna`.\n"
+      "       (scikit-optimize was archived upstream in 2024 and has been removed.)"
+    )
+
+  for key, hint in LEGACY_SOLVER_KEYS.items():
+    if key in solver:
+      raise ValueError(
+        f"ERROR: `solver.{key}` was a scikit-optimize setting and is not supported anymore: {hint}.\n"
+        "       See https://samsung.github.io/qaboard/docs/auto-optimization"
+      )
+
+  sampler_name = solver.pop('sampler', 'gp')
+  if sampler_name not in SAMPLERS:
+    raise ValueError(
+      f"ERROR: unknown `solver.sampler: {sampler_name}`. Expected one of: {', '.join(SAMPLERS)}."
+    )
+
+  seed = solver.pop('seed', 42)
+  n_startup_trials = solver.pop('n_startup_trials', 10)
+  if solver:
+    raise ValueError(
+      f"ERROR: unknown solver settings: {', '.join(sorted(solver))}.\n"
+      f"       Expected: sampler, n_startup_trials, seed."
+    )
+
+  if sampler_name == 'gp':
+    # GPSampler only imports torch once it starts modelling, ie after `n_startup_trials`.
+    # Each of those trials is a full batch run, so we check now rather than crash hours in.
+    try:
+      import torch
+    except ImportError as e:
+      raise ImportError(
+        "`solver.sampler: gp` needs PyTorch, which is not installed.\n"
+        "Install it with:\n"
+        "    pip install 'qaboard[opt]'\n"
+        "or use a sampler that does not need it:\n"
+        "    solver:\n"
+        "      sampler: tpe"
+      ) from e
+    sampler = optuna.samplers.GPSampler(seed=seed, n_startup_trials=n_startup_trials)
+  elif sampler_name == 'tpe':
+    sampler = optuna.samplers.TPESampler(seed=seed, n_startup_trials=n_startup_trials)
+  else:
+    sampler = optuna.samplers.RandomSampler(seed=seed)
+
+  # QA-Board prints its own progress, we don't want Optuna's per-trial chatter
+  optuna.logging.set_verbosity(optuna.logging.WARNING)
+  return optuna.create_study(direction='minimize', sampler=sampler)

--- a/qaboard/optimize.py
+++ b/qaboard/optimize.py
@@ -52,35 +52,39 @@ def optimize(ctx, batches, batches_files, config_file, parallel_param_sampling, 
 
   from shutil import rmtree
   from .api import aggregated_metrics
-  objective, optimizer, optim_config, dim_mapping = init_optimization(config_file, ctx)
+  objective, study, distributions, optim_config, dim_mapping = init_optimization(config_file, ctx)
   if not parallel_param_sampling:
     parallel_param_sampling = optim_config.get('parallel_sampling', 1)
+
+  from optuna.trial import TrialState
 
   # TODO: warm-start
   #   load and "tell" existing results (if there are any)
   #   (or use a checkpoint?)
   for iteration in range(0, optim_config['evaluations'], parallel_param_sampling):
       click.secho(f"Starting iteration {iteration}", fg='blue')
-      if parallel_param_sampling == 1:
-        suggested = optimizer.ask()
-      else:
+      if parallel_param_sampling > 1:
         click.secho(f"  {parallel_param_sampling} parallel samples", fg='blue')
-        suggested = optimizer.ask(n_points=parallel_param_sampling)
+      trials = [study.ask(distributions) for _ in range(parallel_param_sampling)]
+      suggested = [t.params for t in trials]
       # print("suggested", suggested)
       click.secho(f"Computing objective", fg='blue')
       if parallel_param_sampling == 1:
-        y = objective([*suggested, iteration])
+        y = [objective(suggested[0], iteration)]
       else:
-        y = Parallel(n_jobs=parallel_param_sampling)(delayed(objective)([*s, iteration+idx]) for idx, s in enumerate(suggested))
+        y = Parallel(n_jobs=parallel_param_sampling)(delayed(objective)(s, iteration+idx) for idx, s in enumerate(suggested))
       # print(f"y={y}", suggested)
       click.secho(f"Updating optimizer", fg='blue')
-      results = optimizer.tell(suggested, y)
+      for trial, y_iter in zip(trials, y):
+        if y_iter is None:
+          study.tell(trial, state=TrialState.FAIL)
+        else:
+          study.tell(trial, y_iter)
+      # the best value so far, across every iteration -- None until one evaluation succeeds
+      best_value = best_objective(study)
 
       click.secho(f"Updating QA-Board", fg='blue')
-      if parallel_param_sampling == 1:
-        suggested = [suggested]
-        y = [y]
-      for idx, y_iter in enumerate(y): 
+      for idx, y_iter in enumerate(y):
         iteration_batch_label = f"{ctx.obj['batch_label']}|iter{iteration+idx+1}"
         iteration_batch_dir = batch_dir_for(iteration_batch_label)
         metrics = tuple([m for m in optim_config['objective'].keys() if m != 'target'])
@@ -97,26 +101,18 @@ def optimize(ctx, batches, batches_files, config_file, parallel_param_sampling, 
             # but in the exploration see the results per iteration....
             "input_type": 'optim_iteration', # or... single ? don't show them in the UI
             "is_pending": False,
-            "is_failed": False,
+            "is_failed": y_iter is None,
             "metrics": {
               "iteration": iteration+idx+1,
-              "objective": y_iter,
+              **({} if y_iter is None else {"objective": y_iter}),
               **aggregated_metrics_,
             },
           },
         }, command=command)
 
-        # results
-        #    .x [float]: location of the minimum.
-        #    .fun [float]: function value at the minimum.
-        #    .models: surrogate models used for each iteration.
-        #    .x_iters [array]: location of function evaluation for each iteration.
-        #    .func_vals [array]: function value for each iteration.
-        #    .space [Space]: the optimization space.
-        #    .specs [dict]: parameters passed to the function.
-        is_best = results.func_vals[iteration+idx] <= results.fun or iteration+idx==0
+        is_best = y_iter is not None and y_iter <= best_value
         if is_best:
-          click.secho(f'New best @iteration{iteration+idx+1}: {y} at iteration {iteration+idx+1}', fg='green')
+          click.secho(f'New best @iteration{iteration+idx+1}: {y_iter}', fg='green')
 
         is_best_data = {
           "is_best_iter": True,
@@ -142,7 +138,7 @@ def optimize(ctx, batches, batches_files, config_file, parallel_param_sampling, 
         if is_best:
           try:
             click.secho(f'Creating plots', fg='blue')
-            make_plots(results, optim_dir)
+            make_plots(study, optim_dir)
           except:
             pass
         else:
@@ -151,14 +147,27 @@ def optimize(ctx, batches, batches_files, config_file, parallel_param_sampling, 
           print(f"RM {iteration_batch_dir}")
           rmtree(iteration_batch_dir, ignore_errors=True)
 
-  print(results)
-  if not results.models: # needs at least n_initial_points(=5) evaluations!
+  if best_objective(study) is None:
+    click.secho("No evaluation succeeded, there is nothing to report.", fg='red', bold=True)
     return
+  click.secho(f"Best objective: {study.best_value}", fg='green', bold=True)
+  click.secho(f"Best parameters: {dim_mapping(study.best_params)}", fg='green')
 
   # tuning plots are saved in the label directory
-  make_plots(results, optim_dir)
+  make_plots(study, optim_dir)
 
 
+
+
+def best_objective(study):
+  """
+  Best objective value so far, or None if no evaluation succeeded yet.
+  `study.best_value` raises when every trial failed, and failures are expected here:
+  a single batch that does not compute its metrics should not abort the whole search.
+  """
+  from optuna.trial import TrialState
+  values = [t.value for t in study.trials if t.state == TrialState.COMPLETE]
+  return min(values) if values else None
 
 
 def init_optimization(optim_config_file, ctx):
@@ -176,34 +185,24 @@ def init_optimization(optim_config_file, ctx):
     "preset_params": {},
     **optim_config,
   }
-  optim_config['solver'] = {
-    "name": "scikit-optimize",
-    "random_state": 42,
-    **optim_config.get('solver', {}),
-  }
-  from skopt.utils import Space
-  space = Space.from_yaml(optim_config_file, namespace='search_space')
+  from .optimization import make_study, parse_search_space
+  distributions = parse_search_space(optim_config['search_space'])
   preset_params = optim_config.get('preset_params', {})
   click.secho("Search space:", fg="blue", err=True)
-  click.secho(str(space), fg="blue", dim=True, err=True)
+  for name, distribution in distributions.items():
+    click.secho(f"  {name}: {distribution}", fg="blue", dim=True, err=True)
   click.secho("Preset parameters:", fg="blue", err=True)
   click.secho(str(preset_params), fg="blue", dim=True, err=True)
 
-  # we use the iteration step in the objective function, to store results at the right place
-  from skopt.utils import Integer
-  dim_iteration = Integer(name='iteration', low=0, high=2^16)
-  dims = [*space, dim_iteration]
+  def objective(opt_params, iteration):
+    """
+    Run a batch with the suggested parameters, and return its objective value.
+    Returns None if the objective could not be computed, so the caller can mark the
+    trial as failed instead of losing the whole optimization run.
+    """
+    params = {**preset_params, **opt_params}
 
-  from skopt.utils import use_named_args
-
-  @use_named_args(dims)
-  def objective(**opt_params):
-    params =  {**preset_params, **opt_params}
-
-    # From the UI we will want to see the iteration as a metric
-    del params["iteration"]
-
-    batch_label = f"{ctx.obj['raw_batch_label']}|iter{opt_params['iteration']+1}"
+    batch_label = f"{ctx.obj['raw_batch_label']}|iter{iteration+1}"
     command = ' '.join([
       'qa',
       f"--label '{batch_label}'",
@@ -235,22 +234,21 @@ def init_optimization(optim_config_file, ctx):
 
     # Now that we finished computing all the results, we will download the results and
     # compute the objective function:
-    shared_batch_label = f"{ctx.obj['batch_label']}|iter{opt_params['iteration']+1}"
-    return batch_objective(project, commit_id, shared_batch_label, optim_config['objective'])
+    shared_batch_label = f"{ctx.obj['batch_label']}|iter{iteration+1}"
+    try:
+      return batch_objective(project, commit_id, shared_batch_label, optim_config['objective'])
+    except Exception as e:
+      click.secho(f"[ERROR] Could not compute the objective at iteration {iteration+1}: {e}", fg='red', bold=True)
+      return None
 
-  # For the full list of options, refer to:
-  # https://scikit-optimize.github.io/stable/modules/generated/skopt.optimizer.Optimizer.html#skopt.optimizer.Optimizer
-  from skopt import Optimizer
-  del optim_config['solver']['name']
-  optimizer = Optimizer(space, **optim_config['solver'])
+  study = make_study(optim_config['solver'])
 
-  # in the optimization loop, `ask` gives us an array of values
-  # this wrapper converts it back to the actual named parameters
-  @use_named_args([*space])
-  def dim_mapping(**opt_params):
+  # `ask` gives us only the parameters being optimized,
+  # this wrapper adds back the parameters set to fixed values
+  def dim_mapping(opt_params):
     return {**preset_params, **opt_params}
 
-  return objective, optimizer, optim_config, dim_mapping
+  return objective, study, distributions, optim_config, dim_mapping
 
 
 
@@ -357,65 +355,47 @@ def batch_objective(project, commit_id, batch_label, config_objective):
 
 
 
-def make_plots(results, dir):
+def make_plots(study, dir):
   # click.secho(str(dir), dim=True)
   import matplotlib
   import matplotlib.pyplot as plt
   # https://matplotlib.org/faq/usage_faq.html#non-interactive-example
   # https://matplotlib.org/api/_as_gen/matplotlib.pyplot.savefig.html
+  from optuna.visualization.matplotlib import plot_optimization_history, plot_param_importances
 
   if not dir.exists():
     dir.mkdir(parents=True, exist_ok=True)
 
-  # WIP: there is currently no support for plotting categorical variables...
-  # You have to manually checkout this pull request:
-  #   git pr 675  # install https://github.com/tj/git-extras
-  #   git pull origin master 
-  # https://github.com/scikit-optimize/scikit-optimize/pull/675
-  from skopt.plots import plot_convergence
+  # the filenames are what the webapp expects, see webapp/src/components/tuning/TuningExploration.js
   click.secho(f'. plot_convergence', fg='blue')
-  _ = plot_convergence(results)
-  plt.savefig(dir/'plot_convergence.png')
+  plt.figure()
+  plot_optimization_history(study)
+  plt.savefig(dir/'plot_convergence.png', bbox_inches='tight')
+  plt.close()
 
-  # Those plots can be VERY slow.
-  # TODO: create them in the  background
-  # from skopt.plots import plot_objective
-  # click.secho(f'. plot_objective', fg='blue')
-  # _ = plot_objective(results)
-  # plt.savefig(dir/'plot_objective.png')
-
-  # from skopt.plots import plot_regret
-  # click.secho(f'. plot_regret', fg='blue')
-  # _ = plot_regret(results)
-  # plt.savefig(dir/'plot_regret.png')
-
-  # from skopt.plots import plot_evaluations
-  # click.secho(f'. plot_evaluations', fg='blue')
-  # _ = plot_evaluations(results)
-  # plt.savefig(dir/'plot_evaluations.png')
+  # Needs a few completed trials before it means anything, and it is the slowest plot,
+  # so we never let it break the run.
+  try:
+    click.secho(f'. plot_objective', fg='blue')
+    plt.figure()
+    plot_param_importances(study)
+    plt.savefig(dir/'plot_objective.png', bbox_inches='tight')
+    plt.close()
+  except Exception as e:
+    click.secho(f'  (skipped: {e})', fg='yellow', dim=True)
 
 
 
 
 
-# compare convergence...
-# https://github.com/scikit-optimize/scikit-optimize/blob/master/examples/strategy-comparison.ipynb
-# for all runs...
-# from skopt.plots import plot_convergence
-# plot = plot_convergence(("dummy_minimize", dummy_res),
-#                         ("gp_minimize", gp_res),
-#                         ("forest_minimize('rf')", rf_res),
-#                         ("forest_minimize('et)", et_res), 
-#                         true_minimum=0.397887, yscale="log")
-# plot.legend(loc="best", prop={'size': 6}, numpoints=1);
+# compare convergence across runs...
+# https://optuna.readthedocs.io/en/stable/reference/visualization/generated/optuna.visualization.plot_optimization_history.html
+# plot_optimization_history accepts a list of studies:
+# _ = plot_optimization_history([study_gp, study_tpe, study_random])
 
 
-# checkpoints?
-# https://github.com/scikit-optimize/scikit-optimize/blob/master/examples/interruptible-optimization.ipynb
-# https://github.com/scikit-optimize/scikit-optimize/blob/master/examples/store-and-load-results.ipynb
-# poor man's solution:
-# import pickle
-# with open('my-optimizer.pkl', 'wb') as f:
-#     pickle.dump(opt, f)
-# with open('my-optimizer.pkl', 'rb') as f:
-#     opt_restored = pickle.load(f)
+# checkpoints / warm-start?
+# Optuna studies can live in a database instead of memory, which would give us both
+# resumable runs and a way to "tell" past results at startup:
+#   study = optuna.create_study(storage="sqlite:///optim.db", study_name=..., load_if_exists=True)
+# https://optuna.readthedocs.io/en/stable/tutorial/20_recipes/001_rdb.html

--- a/setup.py
+++ b/setup.py
@@ -52,10 +52,16 @@ setup(
     'pyyaml',      # YAML reader
     'joblib',      # Parallelism for dummies
     'scikit-learn',
-    'scikit-optimize',
   ],
 
   extras_require={
+    # auto-tuning (`qa optimize`). Kept optional: torch is a lot to ask of the many
+    # users who only ever run `qa batch`. It is needed by the default `gp` sampler;
+    # `sampler: tpe` and `sampler: random` work with optuna alone.
+    'opt': [
+      'optuna>=4.9',
+      'torch',
+    ],
     'dev': [
       'flake8', # lint
       'green',  # test runner

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1,0 +1,214 @@
+"""
+The search space / solver YAML dialect is a user-facing contract: users write it in the
+web UI and it is saved with their batches. These tests pin the dialect down so it does
+not drift with the optimization engine underneath.
+"""
+import unittest
+
+import yaml
+from optuna.distributions import CategoricalDistribution, FloatDistribution, IntDistribution
+
+from qaboard.optimization import make_study, parse_search_space
+
+
+# Kept in sync with the template users are given in the web UI,
+# see webapp/src/components/tuning/templates.js
+TEMPLATE_SEARCH_SPACE = """
+search_space:
+  - Integer:
+      name: max_events
+      low: 1000
+      high: 10000
+
+  - Categorical:
+      name: solver
+      categories:
+        - ceres
+        - g2o
+
+  - Real:
+      name: threshold
+      low: 0.0
+      high: 1.0
+
+  - Real:
+      name: learning_rate
+      low: 0.0000001
+      high: 0.1
+      prior: log-uniform
+"""
+
+
+def parse(yaml_str):
+  return parse_search_space(yaml.safe_load(yaml_str)['search_space'])
+
+
+class TestSearchSpace(unittest.TestCase):
+  def test_the_webapp_template(self):
+    """The exact search space we hand every user must keep working."""
+    distributions = parse(TEMPLATE_SEARCH_SPACE)
+    self.assertEqual(
+      list(distributions.keys()),
+      ['max_events', 'solver', 'threshold', 'learning_rate'],
+    )
+    self.assertEqual(distributions['max_events'], IntDistribution(1000, 10000))
+    self.assertEqual(distributions['solver'], CategoricalDistribution(['ceres', 'g2o']))
+    self.assertEqual(distributions['threshold'], FloatDistribution(0.0, 1.0))
+    self.assertEqual(distributions['learning_rate'], FloatDistribution(1e-7, 0.1, log=True))
+
+  def test_log_uniform_prior(self):
+    space = parse("search_space:\n  - Integer: {name: n, low: 1, high: 100, prior: log-uniform}")
+    self.assertTrue(space['n'].log)
+
+  def test_uniform_is_the_default_prior(self):
+    space = parse("search_space:\n  - Real: {name: x, low: 1, high: 2}")
+    self.assertFalse(space['x'].log)
+    space = parse("search_space:\n  - Real: {name: x, low: 1, high: 2, prior: uniform}")
+    self.assertFalse(space['x'].log)
+
+  def test_categories_keep_their_order(self):
+    space = parse("search_space:\n  - Categorical: {name: c, categories: [b, a, c]}")
+    self.assertEqual(space['c'].choices, ('b', 'a', 'c'))
+
+  def _assert_error(self, yaml_str, *expected_in_message):
+    with self.assertRaises(ValueError) as context:
+      parse(yaml_str)
+    for expected in expected_in_message:
+      self.assertIn(expected, str(context.exception))
+
+  # Those errors are shown to users in the web UI, so they must say what is wrong and where
+  def test_error_empty(self):
+    self._assert_error("search_space:", 'search_space')
+
+  def test_error_not_a_list(self):
+    self._assert_error("search_space: {a: 1}", 'must be a list')
+
+  def test_error_unknown_dimension(self):
+    self._assert_error("search_space:\n  - Float: {name: x, low: 0, high: 1}", 'Float')
+
+  def test_error_missing_name(self):
+    self._assert_error("search_space:\n  - Real: {low: 0, high: 1}", 'search_space[0]', 'name')
+
+  def test_error_missing_bounds(self):
+    self._assert_error("search_space:\n  - Real: {name: x, low: 0}", '`x`', 'high')
+
+  def test_error_inverted_bounds(self):
+    self._assert_error("search_space:\n  - Real: {name: x, low: 1, high: 0}", '`x`', '>=')
+
+  def test_error_missing_categories(self):
+    self._assert_error("search_space:\n  - Categorical: {name: c}", '`c`', 'categories')
+
+  def test_error_duplicate_name(self):
+    self._assert_error(
+      "search_space:\n  - Real: {name: x, low: 0, high: 1}\n  - Real: {name: x, low: 0, high: 1}",
+      'more than once',
+    )
+
+  def test_error_unknown_prior(self):
+    self._assert_error("search_space:\n  - Real: {name: x, low: 1, high: 2, prior: normal}", 'normal')
+
+  def test_error_log_uniform_needs_positive_bounds(self):
+    self._assert_error(
+      "search_space:\n  - Real: {name: x, low: 0, high: 1, prior: log-uniform}",
+      'log-uniform', '> 0',
+    )
+
+
+def has_torch():
+  try:
+    import torch
+    return True
+  except ImportError:
+    return False
+
+
+class TestSolver(unittest.TestCase):
+  @unittest.skipUnless(has_torch(), "the default `gp` sampler needs torch")
+  def test_defaults(self):
+    study = make_study({})
+    self.assertEqual(study.direction.name, 'MINIMIZE')
+    self.assertEqual(type(study.sampler).__name__, 'GPSampler')
+
+  @unittest.skipIf(has_torch(), "only checks the missing-torch path")
+  def test_gp_without_torch_fails_immediately(self):
+    """
+    GPSampler only imports torch after `n_startup_trials`. Since every trial is a full
+    batch run, a late crash would waste hours: we want the error before trial 1.
+    """
+    with self.assertRaises(ImportError) as context:
+      make_study({'sampler': 'gp'})
+    self.assertIn('qaboard[opt]', str(context.exception))
+    self.assertIn('tpe', str(context.exception))
+
+  def test_samplers(self):
+    for sampler, expected in [('tpe', 'TPESampler'), ('random', 'RandomSampler')]:
+      study = make_study({'sampler': sampler})
+      self.assertEqual(type(study.sampler).__name__, expected)
+
+  def test_error_unknown_sampler(self):
+    with self.assertRaises(ValueError) as context:
+      make_study({'sampler': 'grid'})
+    self.assertIn('grid', str(context.exception))
+
+  def test_error_unknown_setting(self):
+    with self.assertRaises(ValueError) as context:
+      make_study({'sampler': 'tpe', 'nb_startup_trials': 3})
+    self.assertIn('nb_startup_trials', str(context.exception))
+
+  # Users have saved configs written for the old scikit-optimize solver.
+  # We refuse them with an explanation rather than silently ignoring them.
+  def test_error_legacy_skopt_settings(self):
+    for legacy, expected in [
+      ('base_estimator', 'sampler'),
+      ('n_initial_points', 'n_startup_trials'),
+      ('random_state', 'seed'),
+      ('acq_func', 'acquisition'),
+    ]:
+      with self.assertRaises(ValueError) as context:
+        make_study({legacy: 'whatever'})
+      self.assertIn(legacy, str(context.exception))
+      self.assertIn(expected, str(context.exception))
+
+  def test_error_legacy_solver_name(self):
+    with self.assertRaises(ValueError) as context:
+      make_study({'name': 'scikit-optimize'})
+    self.assertIn('optuna', str(context.exception))
+
+
+class TestAskTell(unittest.TestCase):
+  def test_optimizes(self):
+    """A full ask/tell loop, the way qaboard/optimize.py drives it."""
+    distributions = parse(TEMPLATE_SEARCH_SPACE)
+    study = make_study({'sampler': 'random', 'seed': 0})
+    for _ in range(20):
+      trial = study.ask(distributions)
+      params = trial.params
+      self.assertEqual(set(params.keys()), set(distributions.keys()))
+      self.assertIn(params['solver'], ['ceres', 'g2o'])
+      self.assertTrue(1000 <= params['max_events'] <= 10000)
+      study.tell(trial, (params['threshold'] - 0.3) ** 2)
+    self.assertLess(study.best_value, 0.1)
+
+  def test_failed_trials_do_not_stop_the_search(self):
+    from optuna.trial import TrialState
+    distributions = parse("search_space:\n  - Real: {name: x, low: 0, high: 1}")
+    study = make_study({'sampler': 'random', 'seed': 0})
+    for i in range(10):
+      trial = study.ask(distributions)
+      if i % 2:
+        study.tell(trial, state=TrialState.FAIL)
+      else:
+        study.tell(trial, trial.params['x'])
+    completed = [t for t in study.trials if t.state == TrialState.COMPLETE]
+    self.assertEqual(len(completed), 5)
+    self.assertIsNotNone(study.best_value)
+
+  def test_parallel_sampling_gives_distinct_suggestions(self):
+    distributions = parse(TEMPLATE_SEARCH_SPACE)
+    study = make_study({'sampler': 'tpe', 'seed': 0})
+    trials = [study.ask(distributions) for _ in range(4)]
+    self.assertEqual(len({t.number for t in trials}), 4)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/webapp/src/components/tuning/forms.js
+++ b/webapp/src/components/tuning/forms.js
@@ -569,7 +569,7 @@ class TuningForm extends Component {
       {search_type === "optimize" && <>
         <Callout icon="info-sign" title="About auto-tuning">
           <ul>
-          <li>The solver is <a href="https://github.com/scikit-optimize/scikit-optimize">scikit-optimize</a>. There are lots of choices for black-box optimization (nevergrad, RoBo, MOE, Ray, hyperopt, SMAC, BayesOpt, spearmint, dlib...), all with varying features, maturity, algorithms and popularity.</li>
+          <li>The solver is <a href="https://optuna.org/">Optuna</a>. There are lots of choices for black-box optimization (Ax/BoTorch, SMAC, nevergrad, Ray Tune, hyperopt...), all with varying features, maturity, algorithms and popularity.</li>
           <li>You need to use <a href="https://samsung.github.io/qaboard/docs/computing-quantitative-metrics">QA-Board metrics</a>.</li>
           </ul>
           <p><strong>Do send <a href="mailto:arthur.flam@samsung.com">feedback</a>!</strong></p>

--- a/webapp/src/components/tuning/templates.js
+++ b/webapp/src/components/tuning/templates.js
@@ -79,12 +79,11 @@ evaluations: 50
 parallel_sampling: 1
 
 # You can configure the the solver:
-# https://scikit-optimize.github.io/stable/modules/generated/skopt.optimizer.Optimizer.html#skopt.optimizer.Optimizer
+# https://samsung.github.io/qaboard/docs/auto-optimization
 # solver:
-#   base_estimator: GP
-#   n_initial_points: 10
-#   acq_funcstring: gp_hedge
-#   # etc
+#   sampler: gp          # gp (gaussian processes) | tpe | random
+#   n_startup_trials: 10 # random exploration before the sampler kicks in
+#   seed: 42
 
 
 # You can optimize objective functions of the form:
@@ -137,7 +136,7 @@ objective:
 
 search_space:
   # Below are some examples.
-  # More info at https://scikit-optimize.github.io/stable/modules/classes.html#module-skopt.space.space
+  # More info at https://samsung.github.io/qaboard/docs/auto-optimization
   - Integer:
       name: max_events
       low: 1000

--- a/website/docs/auto-optimization.md
+++ b/website/docs/auto-optimization.md
@@ -7,17 +7,107 @@ title: Auto-Optimization
 
 ### `qa optimize`
 > **EXPERIMENTAL**: This feature is experimental and the API is subject to change at any time.
-> 
-> Specifically, we may change the solver backend to `nevergrad`, offer multiple choices, etc.
 
-You need the `scikit-opt` package, which you can install with
+QA-Board can search for the parameters that minimize your [metrics](computing-quantitative-metrics), using black-box optimization. You can start a run from the web UI ("Tuning" > "Automated tuning"), or from the CLI.
+
+You need the optimization extra, which you can install with
 ```bash
-pip install qaboard[opt]
+pip install 'qaboard[opt]'
 ```
 
 ```bash
+qa optimize --config-file optimize.yaml --batch my-batch
 qa optimize --help
 ```
 
-> **WIP**: We're working on section about "auto-optimization". *Stay tuned!*
+## Configuration
 
+The configuration is a YAML file — the same one you edit in the web UI.
+
+```yaml
+# We will call the objective function that many times
+evaluations: 50
+# How many parameter sets to evaluate at once
+parallel_sampling: 1
+
+solver:
+  sampler: gp          # gp (gaussian processes) | tpe | random
+  n_startup_trials: 10 # random exploration before the sampler kicks in
+  seed: 42
+
+objective:
+  my_metric:
+    weight: 1
+    reduce: sum
+    loss: identity
+
+# In addition to the auto-tuning, you can set tuning parameters to fixed values
+preset_params:
+  my_block|debug: false
+
+search_space:
+  - Integer:
+      name: max_events
+      low: 1000
+      high: 10000
+
+  - Categorical:
+      name: solver
+      categories:
+        - ceres
+        - g2o
+
+  - Real:
+      name: threshold
+      low: 0.0
+      high: 1.0
+
+  - Real:
+      name: learning_rate
+      low: 0.0000001
+      high: 0.1
+      prior: log-uniform
+```
+
+### `search_space`
+
+A list of the parameters to optimize. Each is one of:
+
+| Type | Options |
+|:--|:--|
+| `Integer` | `name`, `low`, `high`, optional `prior` |
+| `Real` | `name`, `low`, `high`, optional `prior` |
+| `Categorical` | `name`, `categories` |
+
+`prior` is either `uniform` (default) or `log-uniform`. Use `log-uniform` for parameters that span orders of magnitude, like learning rates — it requires `low > 0`.
+
+Parameters are sent to your runs like any other [tuning parameter](tuning-from-the-webapp).
+
+### `solver`
+
+| Setting | Default | Description |
+|:--|:--|:--|
+| `sampler` | `gp` | `gp` for bayesian optimization with gaussian processes, `tpe` for tree-structured Parzen estimators (cheaper in high dimensions), `random` for a random search baseline |
+| `n_startup_trials` | `10` | Random evaluations before the sampler starts modelling the objective |
+| `seed` | `42` | For reproducible runs |
+
+### `objective`
+
+The objective is minimized, and has the form:
+
+```
+argmin        ∑     ɛ * weight * reduce(   ⋃     loss(metric, target) ) / nb_outputs
+params     metrics                      outputs
+```
+
+Metrics that need to be maximized are handled automatically via each metric's `smaller_is_better` configuration (`ɛ = 1 if smaller_is_better else -1`).
+
+- `reduce`: `sum` (default), `l1`, `l2`, or `relu`
+- `loss`: `identity` (default), `shift`, `relative`, `relu_X`, or `square_X`
+- `target`: which reference values the loss compares against — by default the targets from your metrics configuration, or the results of a given `branch`/`id` and `batch`.
+
+## Under the hood
+
+The solver is [Optuna](https://optuna.org/), driven through its ask/tell API. QA-Board owns the configuration format above, so the solver can be changed without breaking your saved configs.
+
+> Before 2026 the solver was [scikit-optimize](https://github.com/scikit-optimize/scikit-optimize), which was archived upstream in 2024 and never became compatible with numpy 2. The `search_space` and `objective` sections are unchanged, but the `solver` section is not: `base_estimator` is now `sampler`, `n_initial_points` is now `n_startup_trials`, `random_state` is now `seed`, and the acquisition-function settings (`acq_func`, `acq_funcstring`...) are gone. `qa optimize` will tell you if it finds an old setting.

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -24,7 +24,7 @@ QA-Board has become a key collaborative tool at Samsung SIRC. Our main use-cases
 - **Work-from-home**: engineers can share 108MP+ images thanks to the [IIIF protocol](https://github.com/IIIF/awesome-iiif).
 - **Integration**: links to and from git repositories and their Continuous Integration. From QA-Board, users can [directly access](https://samsung.github.io/qaboard/docs/triggering-third-party-tools) build artifacts, trigger automated jobs, and when needed they can build dashboards or scripts they query QA-Board's API.
 - **Visualizations**: everything can be compared, and thanks to the [many different types of visualizations](https://samsung.github.io/qaboard/docs/visualizations) (images/plots/text/html/video...), users can easily create the reports they need.
-- **Tuning**: QA-Board distributes runs to our cluster. Users can easily start tuning experiments that enable feature flags or tweak parameters. We've integrated [scikit-optimize](https://scikit-optimize.github.io/) for black-box optimization.
+- **Tuning**: QA-Board distributes runs to our cluster. Users can easily start tuning experiments that enable feature flags or tweak parameters. We've integrated [Optuna](https://optuna.org/) for black-box optimization.
 - **Regression**: users can check the progress on various metrics, and when needed, identify which commit caused a regression.
 - **Performance engineering**: save [`rr`](https://rr-project.org/)/[`perf`](http://www.brendangregg.com/perf.html) recordings, view [flame graphs](http://www.brendangregg.com/flamegraphs.html) and track metrics for regressions.
 

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -131,7 +131,7 @@ export default function Home() {
               <a href="https://samsung.github.io/qaboard/docs/batches-running-on-multiple-inputs">Define batches of inputs</a> to run on files/databases that matter to you. Start tuning experiments to compare parameters or feature flags  
             </p>
             <p>
-              Use Grid-Search or <strong>Black-box optimization</strong> (via <a href="https://scikit-optimize.github.io/">scikit-optimize</a>), and analyse trade-offs. Use <a href="https://github.com/Samsung/qaboard/wiki/Adding-new-runners">common tools</a> for distributed runs.
+              Use Grid-Search or <strong>Black-box optimization</strong> (via <a href="https://optuna.org/">Optuna</a>), and analyse trade-offs. Use <a href="https://github.com/Samsung/qaboard/wiki/Adding-new-runners">common tools</a> for distributed runs.
             </p>
             <iframe style={{maxWidth: "450px"}} width="100%" height="315" src="https://www.youtube.com/embed/XN71PBr0Rvg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
           </>


### PR DESCRIPTION
scikit-optimize was archived upstream on 2024-02-28 and never became compatible with numpy 2, so `qa optimize` could not even be imported on a modern environment.

The search space YAML was not just an internal detail: users author it in the web UI and it is saved with their batches, but the dialect *was* `skopt.Space.from_yaml()`, so the user-facing format went down with the library. QA-Board now owns that dialect in `qaboard/optimization.py`, and the engine below it is swappable. `search_space` and `objective` configs keep working unchanged.

The solver is now Optuna, driven through its ask/tell API:
- `solver` settings are QA-Board's own instead of raw skopt kwargs. Configs using the old ones are refused with the new spelling rather than silently ignored (`base_estimator` -> `sampler`, `n_initial_points` -> `n_startup_trials`, `random_state` -> `seed`, acquisition-function settings are gone).
- A batch that fails to compute its metrics now marks that trial failed instead of aborting the whole search.
- `plot_objective.png`, which the tuning UI has always displayed as "not yet available", is now produced as a parameter-importance plot.

Optuna moves to a `qaboard[opt]` extra, which is what the docs already told users to install. Its default `gp` sampler needs torch and only imports it after `n_startup_trials`, so we check for it upfront -- every trial is a full batch run, and a crash ten trials in wastes hours.


Claude-Session: https://claude.ai/code/session_013tQSTSYzjen7HkaimZpc6Z